### PR TITLE
adding handling for rejected httpsGet promises

### DIFF
--- a/main.js
+++ b/main.js
@@ -102,7 +102,7 @@ async function updateStatus() {
                 if(doReturn) return;
                 //console.log("checked " + subreddits[section][subreddit].name)
                 if(data.startsWith("<")) {
-                    console.log("We're probably getting blocked... - " + resp);
+                    console.log("We're probably getting blocked... - " + data);
                     setTimeout(() => {
                         updateStatus();
                     }, 10000);

--- a/main.js
+++ b/main.js
@@ -160,10 +160,7 @@ async function updateStatus() {
                 }
             }).catch(function (err) {
                 console.log("We're probably getting blocked... - " + err);
-                setTimeout(() => {
-                    updateStatus();
-                }, 10000);
-                doReturn = true;
+                stop();
                 return;
             });
         }

--- a/main.js
+++ b/main.js
@@ -142,6 +142,13 @@ async function updateStatus() {
                     console.log("FINISHED CHECK (or close enough to) - num " + checkCounter);
                     return;
                 }
+            }).catch(function (err) {
+                console.log("We're probably getting blocked... - " + err);
+                setTimeout(() => {
+                    updateStatus();
+                }, 10000);
+                doReturn = true;
+                return;
             });
         }
     }


### PR DESCRIPTION
this pr adds handling in `updateStatus()` for when a `Promise` returned by `request.httpsGet` is rejected. as mentioned in #17, currently it seems like there isn’t any handling for this scenario.

as a rejected promise would imply something going wrong with the https request, i basically just took a copy of the `console.log` and `setTimeout` statements added in 6c29c87, and chucked them in a `.catch`.

depending on what the underlying problem behind #17 is, this *may or may not* fix the issue there.

(i also changed a reference to `resp` to `data` in one of the `console.log` calls, as at that point in the code the variable `resp` doesn’t exist.)

also: disclaimer, although i think it does, i have no idea if this code actually works or not as i can’t test it myself. feel free to modify/ignore if it doesn’t.