### PR TITLE
Make buttons use `<button>` elements, improve button accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,14 +13,13 @@
 
 <body>
     <div class="large-counter large-counter-hidden" id="large-counter">
-        <div class="large-counter-close" onclick="toggleLargeCounter()">X</div>
+        <button class="large-counter-close" onclick="toggleLargeCounter()">X</button>
         <div class="large-counter-inner">
             <h1><span class="odemeter" id="lc-count">52</span><small id="lc-max">/amount</small></h1>
         </div>
         <div class="large-counter-history" id="counter-history">
             
         </div>
-    </div>
     </div>
     <header>
         <small>Watch a 24/7 stream of this site at <a href="https://twitch.tv/reddark_247">twitch.tv/reddark_247!</a></small>
@@ -44,13 +43,13 @@
     </header>
     <div class="tools">
         <div class="tools-inner">
-            <div class="toggle" onclick="hidePublicSubreddits()" id="hide-public">
+            <button class="toggle" onclick="hidePublicSubreddits()" id="hide-public">
                 <div class="toggle-box"></div>
                 <p>Hide public subreddits</p>
-            </div>
+            </button>
             <div class="tools-left">
-                <div class="button" onclick="toggleLargeCounter()">Large counter</div>
-                <div class="button" id="enable_sounds">Enable sound alerts</div>
+                <button class="button" onclick="toggleLargeCounter()">Large counter</button>
+                <button class="button" id="enable_sounds">Enable sound alerts</button>
             </div>
         </div>
     </div>

--- a/public/index.css
+++ b/public/index.css
@@ -7,6 +7,8 @@
     --background-body: #202b38;
     --background: #161f27;
     --background-alt: #1a242f;
+    --background-button: #202b38;
+    --background-button-hover: #253240;
     --selection: #c0d5e8;
     --text-main: #e9f4fc;
     --text-bright: #c7d2dd;
@@ -270,10 +272,32 @@ a {
 .history-item h3 {
     font-size: 10px !important;
 }
+/* button style reset from https://css-tricks.com/overriding-default-button-styles/ */
+button {
+    color: inherit;
+    border: none;
+    background: none;
+    font-family: inherit;
+    font-size: 100%;
+    line-height: 1.15;
+    margin: 0;
+    overflow: visible;
+    text-transform: none;
+    -webkit-appearance: button;
+    text-align: inherit;
+}
+
 .button {
     padding: 8px 14px;
-    background-color: var(--background-body);
+    background-color: var(--background-button);
     border-radius: 900px;
+    cursor: pointer;
+    text-align: center;
+}
+.button:hover {
+    background-color: var(--background-button-hover);
+}
+#hide-public {
     cursor: pointer;
 }
 
@@ -308,6 +332,7 @@ light {
     background-color: #fff1;
     border-radius: 32px;
     position: relative;
+    flex-shrink: 0;
 }
 
 .toggle {
@@ -458,6 +483,10 @@ footer img {
     position: fixed;
     top: 50px;
     left: 50px;
+    cursor: pointer;
+}
+.large-counter-close:hover {
+    background-color: #fff6;
 }
 
 .odometer.odometer-auto-theme,


### PR DESCRIPTION
This changes the buttons to use `<button>` tags so that you can use them using the keyboard.  It also adds `cursor: pointer` styles to the "Hide public subreddits" and large counter close buttons, and changes the background colors of most buttons on hover.

(I've tested the button styling, and it's consistent on Chrome, Firefox, and Safari)