### PR TITLE
Swap heavy font weight for semibold

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -166,7 +166,7 @@ a {
     color: #00ffaa !important;
     text-shadow: 0px 0px 20px #00ffaa !important;
     margin-bottom: 15px;
-    font-weight: 900;
+    font-weight: 700;
     position: relative;
 }
 
@@ -293,7 +293,7 @@ a {
 }
 
 strong {
-    font-weight: 900;
+    font-weight: 700;
 }
 
 light {


### PR DESCRIPTION
Replaces the heavy (900) font weight, currently used in `.subreddit-private` and `<strong>`, with semibold (700). Improves readability (especially with the Segoe UI and Ubuntu fonts) and reduces the visual "heaviness" of the text itself, which helps to balance out the weight of the colored elements.