### PR TITLE
[Suggestion] Restrict update alert amount + reduce alert display time

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -22,6 +22,7 @@ var socket = io();
 var subreddits = {};
 var amount = 0;
 var dark = 0;
+var statusUpdateItems = [];
 
 var loaded = false;
 socket.on("subreddits", (data) => {
@@ -153,13 +154,24 @@ function updateStatusText() {
     od.update(dark);
     document.getElementById("lc-max").innerHTML = " <light>out of</light> " + amount;
 }
+
 function newStatusUpdate(text, callback = null, _classes = []) {
     var item = Object.assign(document.createElement("div"), { "className": "status-update" });
     item.innerHTML = text;
+
+    if (statusUpdateItems.length >= 3) {
+        const itemToRemove = x.pop();
+        if (document.contains(itemToRemove)) {
+            itemToRemove.remove();
+        }
+    }
+
+    statusUpdateItems.unshift(item);
+
     document.getElementById("statusupdates").appendChild(item);
     setTimeout(() => {
         item.remove();
-    }, 20000);
+    }, 10000);
 
     item.addEventListener("click", function () {
         item.remove();


### PR DESCRIPTION
Since its 1am UTC a lot of alerts are popping up as subreddits go Dark.

This PR restricts the amount of alerts that appear at one time to 3, and reduces the display time to 10 seconds which I think is more suitable😃 ( Feel free to ignore though )