### PR TITLE
Allow immediately opening up large counter view via URL

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -192,3 +192,17 @@ od = new Odometer({
     theme: 'default'
 });
 
+
+window.addEventListener('load', function() {
+    // see if we got passed any options
+    if (typeof this.window.location.hash === 'string') {
+        const hashWords = this.window.location.hash.replace(/^#/, '').split('&');
+        console.log('hash:', hashWords);
+        // automatically show large counter?
+        if (hashWords.indexOf('largeCounter') >= 0) {
+            toggleLargeCounter();
+        }
+    } else {
+        console.log('no hash');
+    }
+})


### PR DESCRIPTION
Make it so a call to `/#largeCounter` makes the JavaScript open up the large counter view immediately. This would be nice to have for an automated view.